### PR TITLE
Add ability to change tinc network name and support for different routing modes

### DIFF
--- a/tinc-vpn-client/DOCS.md
+++ b/tinc-vpn-client/DOCS.md
@@ -24,6 +24,7 @@ Add-on configuration:
   server_name: server01
   server_public_key: paste-server-public-key-base64
   connect_to: tinc-server-fqdn-or-ip
+  network_name: tinc0
   server_subnet: 10.0.0.1/32
   client_name: client01
   public_key: paste-client-public-key-base64
@@ -31,6 +32,7 @@ Add-on configuration:
   client_subnet: 10.0.0.2/32
   client_route: 10.0.0.0/24
   address_family: ipv4
+  mode: router
 ```
 
 ### Option: `server_name` (required)
@@ -44,6 +46,10 @@ Convert server public key to base64 format and fill the field.
 ### Option: `connect_to` (required)
 
 Specifies which other tinc daemon to connect to on startup.
+
+### Option: `network_name` (required)
+
+The name of your tinc network. 
 
 ### Option: `server_subnet` (required)
 
@@ -72,6 +78,10 @@ Set client network route which will be used for `tinc-up` and `tinc-down` script
 ### Option `address_family` (required)
 
 This option affects the address family of listening and outgoing sockets.
+
+### Option `mode` (required)
+
+One of "swtich", "router" or hub. 
 
 ## Support
 

--- a/tinc-vpn-client/DOCS.md
+++ b/tinc-vpn-client/DOCS.md
@@ -81,7 +81,7 @@ This option affects the address family of listening and outgoing sockets.
 
 ### Option `mode` (required)
 
-One of "swtich", "router" or hub. 
+One of "router", "switch" or "hub". Router is the default mode, and unless you really know you need another mode, don't change it.
 
 ## Support
 

--- a/tinc-vpn-client/config.yaml
+++ b/tinc-vpn-client/config.yaml
@@ -20,6 +20,7 @@ options:
   server_name: server01
   server_public_key: paste-server-public-key-base64
   connect_to: tinc-server-fqdn-or-ip
+  network_name: tinc0
   server_subnet: 10.0.0.1/32
   client_name: client01
   public_key: paste-client-public-key-base64
@@ -27,10 +28,12 @@ options:
   client_subnet: 10.0.0.2/32
   client_route: 10.0.0.0/24
   address_family: ipv4
+  mode: router
 schema:
   server_name: str
   server_public_key: str
   connect_to: str
+  network_name: str
   server_subnet: str
   client_name: str
   public_key: str
@@ -38,3 +41,4 @@ schema:
   client_subnet: str
   client_route: str
   address_family: list(ipv4|ipv6)
+  mode: str

--- a/tinc-vpn-client/run.sh
+++ b/tinc-vpn-client/run.sh
@@ -5,6 +5,7 @@ CONFIG_PATH=/data/options.json
 SERVERNAME=$(bashio::config 'server_name')
 SERVERPUBLICKEY=$(bashio::config 'server_public_key')
 TINCSERVER=$(bashio::config 'connect_to')
+TINCNETNAME=$(bashio::config 'network_name')
 SERVERSUBNET=$(bashio::config 'server_subnet')
 CLIENTNAME=$(bashio::config 'client_name')
 PUBLICKEY=$(bashio::config 'public_key')
@@ -12,6 +13,7 @@ PRIVATEKEY=$(bashio::config 'private_key')
 CLIENTSUBNET=$(bashio::config 'client_subnet')
 CLIENTROUTE=$(bashio::config 'client_route')
 ADDRESSFAMILY=$(bashio::config 'address_family')
+TINCMODE=$(bashio::config 'mode')
 
 function init_tun(){
     mkdir -p /dev/net
@@ -21,56 +23,58 @@ function init_tun(){
 }
 
 function generate_private_key(){
-    tincd -n tinc0 -K4096
+    tincd -n ${TINCNETNAME} -K4096
 }
 
 function generate_config_files(){
-    mkdir -p /etc/tinc/tinc0/hosts
+    mkdir -p /etc/tinc/${TINCNETNAME}/hosts
 
-    cat <<EOF > /etc/tinc/tinc0/tinc-up
+    cat <<EOF > /etc/tinc/${TINCNETNAME}/tinc-up
 #!/bin/sh
 ip link set \$INTERFACE up
 ip addr add ${CLIENTSUBNET} dev \$INTERFACE
 ip route add ${CLIENTROUTE} dev \$INTERFACE
 EOF
 
-    cat <<EOF > /etc/tinc/tinc0/tinc-down
+    cat <<EOF > /etc/tinc/${TINCNETNAME}/tinc-down
 #!/bin/sh
 ip route del ${CLIENTROUTE} dev \$INTERFACE
 ip addr del ${CLIENTSUBNET} dev \$INTERFACE
 ip link set \$INTERFACE down
 EOF
 
-    cat <<EOF > /etc/tinc/tinc0/tinc.conf
+    cat <<EOF > /etc/tinc/${TINCNETNAME}/tinc.conf
 Name = ${CLIENTNAME}
 AddressFamily = ${ADDRESSFAMILY}
-Interface = tinc0
+Interface = tun0
 ConnectTo = ${SERVERNAME}
+Mode = ${TINCMODE}
+
 EOF
 
-    cat <<EOF > /etc/tinc/tinc0/hosts/${CLIENTNAME}
+    cat <<EOF > /etc/tinc/${TINCNETNAME}/hosts/${CLIENTNAME}
 Subnet = ${CLIENTSUBNET}
 
 
 EOF
 
-    cat <<EOF > /etc/tinc/tinc0/hosts/${SERVERNAME}
+    cat <<EOF > /etc/tinc/${TINCNETNAME}/hosts/${SERVERNAME}
 Subnet = ${SERVERSUBNET}
 Address = ${TINCSERVER}
 
 
 EOF
 
-    echo ${PUBLICKEY} | base64 -d >> /etc/tinc/tinc0/hosts/${CLIENTNAME}
-    echo ${SERVERPUBLICKEY} | base64 -d >> /etc/tinc/tinc0/hosts/${SERVERNAME}
-    echo ${PRIVATEKEY} | base64 -d > /etc/tinc/tinc0/rsa_key.priv
+    echo ${PUBLICKEY} | base64 -d >> /etc/tinc/${TINCNETNAME}/hosts/${CLIENTNAME}
+    echo ${SERVERPUBLICKEY} | base64 -d >> /etc/tinc/${TINCNETNAME}/hosts/${SERVERNAME}
+    echo ${PRIVATEKEY} | base64 -d > /etc/tinc/${TINCNETNAME}/rsa_key.priv
 
-    chmod 600 /etc/tinc/tinc0/rsa_key.priv
-    chmod +x /etc/tinc/tinc0/tinc-up
-    chmod +x /etc/tinc/tinc0/tinc-down
+    chmod 600 /etc/tinc/${TINCNETNAME}/rsa_key.priv
+    chmod +x /etc/tinc/${TINCNETNAME}/tinc-up
+    chmod +x /etc/tinc/${TINCNETNAME}/tinc-down
 }
 
 init_tun
 generate_config_files
 
-tincd -n tinc0 -D -d
+tincd -n ${TINCNETNAME} -D -d


### PR DESCRIPTION
Fix for https://github.com/mdzidic/hassio-tinc-vpn-client/issues/2

Add the ability to select a routing mode in the config.
Add a variable to pass a network name to tincd -n.
Rename the tun device created to tun0 for religious reasons.
Update the DOC.md accordingly. 